### PR TITLE
add a command to insert symbol at point

### DIFF
--- a/ctrlf.el
+++ b/ctrlf.el
@@ -428,11 +428,13 @@ direction is backwards."
 
 (defun ctrlf--symbol-at-point ()
   "Return symbol at point.
-When doing regexp search, wrap it with \"\\_<\" and \"\\_>\"."
+When doing regexp search, wrap it with \"\\_<\" and \"\\_>\". When there's no
+symbol at point, return nil."
   (let ((symbol (thing-at-point 'symbol t)))
-    (if ctrlf--regexp-p
-        (concat "\\_<" (regexp-quote symbol) "\\_>")
-      symbol)))
+    (when symbol
+      (if ctrlf--regexp-p
+          (concat "\\_<" (regexp-quote symbol) "\\_>")
+        symbol))))
 
 (defun ctrlf-first-match ()
   "Move to first match, if there is one."

--- a/ctrlf.el
+++ b/ctrlf.el
@@ -52,8 +52,6 @@ events and the values are command symbols."
     ([remap minibuffer-keyboard-quit]       . ctrlf-cancel)
     ([remap minibuffer-beginning-of-buffer] . ctrlf-first-match)
     ([remap end-of-buffer]                  . ctrlf-last-match)
-    ([remap next-history-element]
-     . ctrlf-next-history-element-or-symbol-at-point)
     ("C-s"       . ctrlf-next-match-or-previous-history-element)
     ("TAB"       . ctrlf-next-match-or-previous-history-element)
     ("C-r"       . ctrlf-previous-match-or-previous-history-element)
@@ -343,7 +341,8 @@ fails, return nil, but still move point."
       (let ((ctrlf--active-p t)
             (cursor-in-non-selected-windows nil))
         (read-from-minibuffer
-         (ctrlf--prompt) nil keymap nil 'ctrlf-search-history)))))
+         (ctrlf--prompt) nil keymap nil 'ctrlf-search-history
+         (ctrlf--symbol-at-point))))))
 
 (defun ctrlf-forward ()
   "Search forward for literal string."
@@ -427,25 +426,13 @@ direction is backwards."
         (previous-history-element 1))
     (ctrlf-previous-match)))
 
-(defun ctrlf-insert-symbol-at-point ()
-  "Use symbol at point to replace user input."
-  (interactive)
-  (let ((symbol (with-selected-window
-                    (minibuffer-selected-window)
-                  (thing-at-point 'symbol t))))
-    (delete-minibuffer-contents)
+(defun ctrlf--symbol-at-point ()
+  "Return symbol at point.
+When doing regexp search, wrap it with \"\\_<\" and \"\\_>\"."
+  (let ((symbol (thing-at-point 'symbol t)))
     (if ctrlf--regexp-p
-        (insert (concat "\\_<" (regexp-quote symbol) "\\_>"))
-      (insert symbol))))
-
-(defun ctrlf-next-history-element-or-symbol-at-point (n)
-  "Use next history element to replace user input.
-With argument N, it uses the Nth following element. When runing out of history,
-the symbol at point is used."
-  (interactive "p")
-  (if (< (- minibuffer-history-position n) 0)
-      (ctrlf-insert-symbol-at-point)
-    (next-history-element n)))
+        (concat "\\_<" (regexp-quote symbol) "\\_>")
+      symbol)))
 
 (defun ctrlf-first-match ()
   "Move to first match, if there is one."

--- a/ctrlf.el
+++ b/ctrlf.el
@@ -24,6 +24,7 @@
 (require 'cl-lib)
 (require 'map)
 (require 'subr-x)
+(require 'thingatpt)
 
 (defgroup ctrlf nil
   "More streamlined replacement for Isearch, Swiper, etc."
@@ -457,6 +458,17 @@ direction is backwards."
   (ctrlf--clear-persistent-overlays)
   (set-window-point (minibuffer-selected-window) ctrlf--starting-point)
   (abort-recursive-edit))
+
+(defun ctrlf-insert-symbol-at-point ()
+  "Use symbol at point to replace user input."
+  (interactive)
+  (let ((symbol (with-selected-window
+                    (minibuffer-selected-window)
+                  (thing-at-point 'symbol t))))
+    (delete-minibuffer-contents)
+    (if ctrlf--regexp-p
+        (insert (concat "\\_<" symbol "\\_>"))
+      (insert symbol))))
 
 (defvar ctrlf--keymap (make-sparse-keymap)
   "Keymap for `ctrlf-mode'. Populated when mode is enabled.


### PR DESCRIPTION
This is an idea mentioned in https://github.com/raxod502/ctrlf/issues/11#issuecomment-580081978.

This patch functions well, but:

1. Currently I don't have an idea about the keybind. `ivy` will insert the symbol at point when you want next history element but there's no more. I am used to this. But I find CTRLF only gives me commands to go to previous history element. So why? And do you think the described behavior is reasonable?

2. If you call `ctrlf-insert-symbol-at-point` for the 2nd time, the match count goes to left, like described in https://github.com/raxod502/ctrlf/issues/2.