### PR TITLE
Add an user option to translate regexp when searching

### DIFF
--- a/ctrlf.el
+++ b/ctrlf.el
@@ -333,9 +333,13 @@ match. If the search fails, return nil, but still move point."
     (goto-char (field-end (point-min))))
   (ctrlf--clear-transient-overlays)
   (cl-block nil
-    (let ((input (field-string (point-max))))
+    (let* ((input (field-string (point-max)))
+           (translator (plist-get
+                        (alist-get ctrlf--style ctrlf-style-alist)
+                        :translator))
+           (regexp (funcall translator input)))
       (condition-case e
-          (when (string-match-p input "")
+          (when (string-match-p regexp "")
             ;; Let's just rule out zero-length matches entirely,
             ;; they're not interesting and they make the
             ;; implementation more complicated and slower.

--- a/ctrlf.el
+++ b/ctrlf.el
@@ -254,34 +254,24 @@ mess."
 
 (cl-defun ctrlf--search
     (query &key
-           (translator :unset) (style :unset)
-           (backward :unset) (forward :unset)
+           (style :unset) (backward :unset) (forward :unset)
            wraparound bound)
   "Single-buffer text search primitive. Search for QUERY.
-TRANSLATOR specifies the function to translate user input to regexp. If it's
-unset, decide based on STYLE and `ctrlf-style-alist'. STYLE controls the search
-style. It's not needed if TRANSLATOR is specified. If both STYLE and TRANSLATOR
-are unset, they are automatically set based on `ctrlf--style'. BACKWARD
-controls whether to do a forward search (nil) or a backward search (non-nil),
-else check `ctrlf--backward-p'. LITERAL and FORWARD do the same but the meaning
-of their arguments are inverted. WRAPAROUND means keep searching at the
-beginning (or end, respectively) of the buffer, rather than stopping. BOUND, if
-non-nil, is a limit for the search as in `search-forward' and friend. Providing
-BOUND automatically disables WRAPAROUND. If the search succeeds, move point to
-the end (for forward searches) or beginning (for backward searches) of the
-match. If the search fails, return nil, but still move point."
-  (let* ((style (when (eq translator :unset)
-                  (cond
-                   ((not (eq style :unset))
-                    style)
-                   (t
-                    ctrlf--style))))
-         (translator (cond
-                      ((not (eq translator :unset))
-                       translator)
-                      (t
-                       (plist-get
-                        (alist-get style ctrlf-style-alist) :translator))))
+STYLE controls the search style. If it's unset, use the value of
+`ctrlf--style'. BACKWARD controls whether to do a forward search (nil) or a
+backward search (non-nil), else check `ctrlf--backward-p'. LITERAL and FORWARD
+do the same but the meaning of their arguments are inverted. WRAPAROUND means
+keep searching at the beginning (or end, respectively) of the buffer, rather
+than stopping. BOUND, if non-nil, is a limit for the search as in
+`search-forward' and friend. Providing BOUND automatically disables
+WRAPAROUND. If the search succeeds, move point to the end (for forward
+searches) or beginning (for backward searches) of the match. If the search
+fails, return nil, but still move point."
+  (let* ((style (cond
+                 ((not (eq style :unset))
+                  style)
+                 (t
+                  ctrlf--style)))
          (backward (cond
                     ((not (eq backward :unset))
                      backward)
@@ -293,7 +283,9 @@ match. If the search fails, return nil, but still move point."
          (func (if backward
                    #'re-search-backward
                  #'re-search-forward))
-         (query (funcall translator query)))
+         (query (funcall
+                 (plist-get (alist-get style ctrlf-style-alist) :translator)
+                 query)))
     (or (funcall func query bound 'noerror)
         (when wraparound
           (goto-char

--- a/ctrlf.el
+++ b/ctrlf.el
@@ -51,7 +51,8 @@ The key is the symbol of the search style, the value is a list composed of the
 displayed name and the regexp translator."
   :type '(alist
           :key-type symbol
-          :value-type (list string function)))
+          :value-type (list (const :prompt) string
+                            (const :translator) function)))
 
 (defcustom ctrlf-mode-bindings
   '(([remap isearch-forward        ] . ctrlf-forward)
@@ -150,7 +151,7 @@ I have literally no idea why this is needed.")
 Assume that S2 has the same properties throughout."
   (apply #'propertize s1 (text-properties-at 0 s2)))
 
- (defun ctrlf--fuzzy-split (str)
+(defun ctrlf--fuzzy-split (str)
   "Split STR into a list of substrs.
 STR is splitted by spaces. A single space is substituted by \".*\", while N
 consecutive spaces are substituted by N-1 spaces."
@@ -442,7 +443,7 @@ match. If the search fails, return nil, but still move point."
             (cursor-in-non-selected-windows nil))
         (read-from-minibuffer
          (ctrlf--prompt) nil keymap nil 'ctrlf-search-history
-         (ctrlf--symbol-at-point))))))
+         (thing-at-point 'symbol t))))))
 
 (defun ctrlf-forward ()
   "Search forward for literal string."
@@ -568,16 +569,6 @@ direction is backwards."
         (setq ctrlf--backward-p t)
         (previous-history-element 1))
     (ctrlf-previous-match)))
-
-(defun ctrlf--symbol-at-point ()
-  "Return symbol at point.
-When doing regexp search, wrap it with \"\\_<\" and \"\\_>\". When there's no
-symbol at point, return nil."
-  (let ((symbol (thing-at-point 'symbol t)))
-    (when symbol
-      (if (memq ctrlf--style '(regexp fuzzy-regexp))
-          (concat "\\_<" (regexp-quote symbol) "\\_>")
-        symbol))))
 
 (defun ctrlf-first-match ()
   "Move to first match, if there is one."

--- a/ctrlf.el
+++ b/ctrlf.el
@@ -153,8 +153,9 @@ Assume that S2 has the same properties throughout."
 
 (defun ctrlf--fuzzy-split (str)
   "Split STR into a list of substrs.
-STR is splitted by spaces. A single space is substituted by \".*\", while N
-consecutive spaces are substituted by N-1 spaces."
+STR is splitted by spaces. A single space is substituted by
+\".*\", while N consecutive spaces are substituted by N-1
+spaces."
   (let* ((last-is-empty t)
          ;; By `split-string', N spaces will become N-1 empty strings, but at
          ;; the beginning/end of the string, they become N empty strings. We'll
@@ -191,8 +192,9 @@ consecutive spaces are substituted by N-1 spaces."
 
 (defun ctrlf--fuzzy-translate (str)
   "Translate the literal input STR to a fuzzy regexp.
-A single space character is translated into \".*\", while N spaces (N >= 2) are
-translated in to N-1 spaces. The groups divided by \".*\" are quotted."
+A single space character is translated into \".*\", while N
+spaces (N >= 2) are translated in to N-1 spaces. The groups
+divided by \".*\" are quoted."
   (let ((substr-replace
          (lambda (substr)
            (if (string= ".*" substr)
@@ -205,8 +207,8 @@ translated in to N-1 spaces. The groups divided by \".*\" are quotted."
 
 (defun ctrlf--fuzzy-regexp-translate (str)
   "Translate the user inputted regexp STR to a fuzzy regexp.
-A single space character is translated into \".*\", while N spaces (N >= 2) are
-translated in to N-1 spaces."
+A single space character is translated into \".*\", while N
+spaces (N >= 2) are translated in to N-1 spaces."
   (apply #'concat (ctrlf--fuzzy-split str)))
 
 (defun ctrlf--finalize ()
@@ -258,15 +260,17 @@ mess."
            wraparound bound)
   "Single-buffer text search primitive. Search for QUERY.
 STYLE controls the search style. If it's unset, use the value of
-`ctrlf--style'. BACKWARD controls whether to do a forward search (nil) or a
-backward search (non-nil), else check `ctrlf--backward-p'. LITERAL and FORWARD
-do the same but the meaning of their arguments are inverted. WRAPAROUND means
-keep searching at the beginning (or end, respectively) of the buffer, rather
-than stopping. BOUND, if non-nil, is a limit for the search as in
-`search-forward' and friend. Providing BOUND automatically disables
-WRAPAROUND. If the search succeeds, move point to the end (for forward
-searches) or beginning (for backward searches) of the match. If the search
-fails, return nil, but still move point."
+`ctrlf--style'. BACKWARD controls whether to do a forward
+search (nil) or a backward search (non-nil), else check
+`ctrlf--backward-p'. LITERAL and FORWARD do the same but the
+meaning of their arguments are inverted. WRAPAROUND means keep
+searching at the beginning (or end, respectively) of the buffer,
+rather than stopping. BOUND, if non-nil, is a limit for the
+search as in `search-forward' and friend. Providing BOUND
+automatically disables WRAPAROUND. If the search succeeds, move
+point to the end (for forward searches) or beginning (for
+backward searches) of the match. If the search fails, return nil,
+but still move point."
   (let* ((style (cond
                  ((not (eq style :unset))
                   style)


### PR DESCRIPTION
This is an idea mentioned in https://github.com/raxod502/ctrlf/issues/11#issuecomment-580081978. The actual logic is:

- Translate a single space into `.*`, and N spaces (N >= 2) into N-1 spaces.
- When space/spaces are escaped, remove the backslash (which should like "do nothing", since AFAIK space isn't a special character in the regexp of Emacs.)

Please see if there is any problem.