### PR TITLE
Make it possible to disable ctrlf-mode locally in buffers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ The format is based on [Keep a Changelog].
   conflict with them. If you remapped the Isearch commands in your
   configuration, this means you will need to update
   `ctrlf-mode-bindings`. See [#51].
+* It is now possible to disable `ctrlf-mode` buffer locally by
+ disabling `ctrlf-local-mode` in mode hooks etc. See [#53].
 
 ### Bugs fixed
 * CTRLF previously caused an error during Emacs startup unless the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,8 @@ The format is based on [Keep a Changelog].
   conflict with them. If you remapped the Isearch commands in your
   configuration, this means you will need to update
   `ctrlf-mode-bindings`. See [#51].
-* It is now possible to disable `ctrlf-mode` buffer locally by
- disabling `ctrlf-local-mode` in mode hooks etc. See [#53].
+* It is now possible to disable `ctrlf-mode` buffer-locally by means
+  of `ctrlf-local-mode` ([#52], [#53]).
 
 ### Bugs fixed
 * CTRLF previously caused an error during Emacs startup unless the
@@ -42,6 +42,8 @@ The format is based on [Keep a Changelog].
 [#49]: https://github.com/raxod502/ctrlf/issues/49
 [#50]: https://github.com/raxod502/ctrlf/pull/50
 [#51]: https://github.com/raxod502/ctrlf/issues/51
+[#52]: https://github.com/raxod502/ctrlf/issues/52
+[#53]: https://github.com/raxod502/ctrlf/pull/53
 
 ## 1.0 (released 2020-03-31)
 ### Added

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ for single-buffer text search in Emacs, replacing packages such as
   * [Search flow](#search-flow)
   * [Customization](#customization)
   * [Search styles](#search-styles)
+  * [Disabling CTRLF locally](#disabling-ctrlf-locally)
   * [Miscellaneous](#miscellaneous)
 - [Why use CTRLF?](#why-use-ctrlf)
   * [Why not Isearch?](#why-not-isearch)
@@ -236,9 +237,9 @@ following steps:
 
 `ctrlf-mode` is a globalized minor mode that enables the buffer-local
 minor mode `ctrlf-local-mode`. This makes it possible to disable it
-locally in mode-hooks etc. An example where this makes sense is
-`pdf-isearch-minor-mode` from
-[pdf-tools](https://github.com/politza/pdf-tools):
+when there is a conflict, for example with `pdf-isearch-minor-mode`
+from [pdf-tools](https://github.com/politza/pdf-tools):
+
 ```elisp
 (add-hook 'pdf-isearch-minor-mode-hook (lambda () (ctrlf-local-mode -1)))
 ```

--- a/README.md
+++ b/README.md
@@ -232,6 +232,17 @@ following steps:
   `ctrlf-forward` and `ctrlf-backward`, respectively, as subroutines.
 * Bind these functions in `ctrlf-mode-bindings`.
 
+### Disabling CTRLF locally
+
+`ctrlf-mode` is a globalized minor mode that enables the buffer-local
+minor mode `ctrlf-local-mode`. This makes it possible to disable it
+locally in mode-hooks etc. An example where this makes sense is
+`pdf-isearch-minor-mode` from
+[pdf-tools](https://github.com/politza/pdf-tools):
+```elisp
+(add-hook 'pdf-isearch-minor-mode-hook (lambda () (ctrlf-local-mode -1)))
+```
+
 ### Miscellaneous
 
 The minibuffer history for CTRLF is stored in the variable

--- a/ctrlf.el
+++ b/ctrlf.el
@@ -1226,13 +1226,12 @@ See `ctrlf-mode-bindings'.")
 
 ;;;###autoload
 (progn
-  (define-minor-mode ctrlf-mode
+  (define-minor-mode ctrlf-local-mode
     "Minor mode to use CTRLF in place of Isearch.
 See `ctrlf-mode-bindings' to customize."
-    :global t
     :keymap ctrlf--keymap
     (require 'map)
-    (when ctrlf-mode
+    (when ctrlf-local-mode
       ;; Hack to clear out keymap. Presumably there's a `clear-keymap'
       ;; function lying around somewhere...?
       (setcdr ctrlf--keymap nil)
@@ -1243,11 +1242,14 @@ See `ctrlf-mode-bindings' to customize."
          (define-key ctrlf--keymap key cmd))
        ctrlf-mode-bindings))
     (with-eval-after-load 'ctrlf
-      (if ctrlf-mode
+      (if ctrlf-local-mode
           (advice-add #'minibuffer-message :around
                       #'ctrlf--minibuffer-message-condense)
         (advice-remove #'minibuffer-message
                        #'ctrlf--minibuffer-message-condense)))))
+
+;;;###autoload
+(define-globalized-minor-mode ctrlf-mode ctrlf-local-mode ctrlf-local-mode)
 
 ;;;; Closing remarks
 


### PR DESCRIPTION
Do this by defining ctrlf-global-mode and let ctrlf-mode be an
ordinary buffer-local minor-mode

See this more as a suggestion, one way of solving problems like #52

----

#