### PR TITLE
Add option to go to the end of the line and make it the default.

### DIFF
--- a/ctrlf.el
+++ b/ctrlf.el
@@ -74,6 +74,10 @@ return nil."
 Otherwise, the match count is only shown in the minibuffer."
   :type 'boolean)
 
+(defcustom ctrlf-go-to-end-of-match t
+  "Non-nil means to go to the end of the match after the search is finished. Otherwise, it goes to the beginning of the match."
+  :type 'boolean)
+
 (defcustom ctrlf-style-alist
   '((literal      . (:prompt "literal"
                              :translator regexp-quote
@@ -699,7 +703,10 @@ later (this should be used at the end of the search)."
             (if (and (not skip-search)
                      (ctrlf--search input :bound 'wraparound))
                 (progn
-                  (goto-char (match-beginning 0))
+                  (goto-char (or
+                              (and ctrlf-go-to-end-of-match
+                                   (match-end 0))
+                              (match-beginning 0)))
                   (setq ctrlf--match-bounds
                         (cons (match-beginning 0)
                               (match-end 0))))


### PR DESCRIPTION
<!--

To expedite the pull request process, please see the contributor guide
for my projects:

  <https://github.com/raxod502/contributor-guide>

-->
This pull request changes the default behavior to go to the end of match on all searches but makes it possible to revert back to ctrlf's old behavior.
I didn't make it isearch-like because it would need dramatic changes in the code.