### PR TITLE
Make ctrlf go to the end of matches.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog].
 
 ## Unreleased
+### Features
+* New user option `ctrlf-go-to-end-of-match`, if non-nil, puts point
+  at the end of a match when exiting a search, rather than the
+  beginning ([#66], [#73])
+
 ### Enhancements
 * Compatibility with evil-mode's jump list and search history features
   was included in [#59]. This integration happens automatically and
   requires no user input/customisation.
 
 [#59]: https://github.com/raxod502/ctrlf/issues/59
+[#66]: https://github.com/raxod502/ctrlf/issues/66
+[#73]: https://github.com/raxod502/ctrlf/pull/73
 
 ## 1.2 (released 2020-10-20)
 ### Features

--- a/README.md
+++ b/README.md
@@ -183,6 +183,11 @@ and `ctrlf-previous-match`. These functions are the same as
 features of inserting the previous search, changing to a literal
 search, or starting a new search when not already in a search session.
 
+You can customize the behavior:
+
+* If `ctrlf-go-to-end-of-match` is nil, then the cursor will move to
+the beginning of the match instead of the end.
+
 ### Search styles
 
 CTRLF implements support for literal and regexp using an extensible

--- a/ctrlf.el
+++ b/ctrlf.el
@@ -704,9 +704,8 @@ later (this should be used at the end of the search)."
             (if (and (not skip-search)
                      (ctrlf--search input :bound 'wraparound))
                 (progn
-                  (goto-char (or
-                              (and ctrlf-go-to-end-of-match
-                                   (match-end 0))
+                  (goto-char (if ctrlf-go-to-end-of-match
+                                 (match-end 0)
                               (match-beginning 0)))
                   (setq ctrlf--match-bounds
                         (cons (match-beginning 0)

--- a/ctrlf.el
+++ b/ctrlf.el
@@ -75,7 +75,8 @@ Otherwise, the match count is only shown in the minibuffer."
   :type 'boolean)
 
 (defcustom ctrlf-go-to-end-of-match t
-  "Non-nil means to go to the end of the match after the search is finished. Otherwise, it goes to the beginning of the match."
+  "Non-nil means to go to the end of the match after the search is finished.
+Otherwise, it goes to the beginning of the match."
   :type 'boolean)
 
 (defcustom ctrlf-style-alist
@@ -862,7 +863,7 @@ For some reason this gets trashed when exiting the minibuffer, so
 we restore it to keep the scroll position consistent.
 
 I have literally no idea why this is needed.")
-
+"this is a test"
 (defun ctrlf--finalize ()
   "Perform cleanup that has to happen after the minibuffer is exited.
 And self-destruct this hook."

--- a/ctrlf.el
+++ b/ctrlf.el
@@ -74,6 +74,10 @@ return nil."
 Otherwise, the match count is only shown in the minibuffer."
   :type 'boolean)
 
+(defcustom ctrlf-go-to-end-of-match t
+  "Non-nil means to go to the end of the match after the search is finished. Otherwise, it goes to the beginning of the match."
+  :type 'boolean)
+
 (defcustom ctrlf-style-alist
   '((literal      . (:prompt "literal"
                              :translator regexp-quote
@@ -699,7 +703,10 @@ later (this should be used at the end of the search)."
             (if (and (not skip-search)
                      (ctrlf--search input :bound 'wraparound))
                 (progn
-                  (goto-char (match-beginning 0))
+                  (goto-char (or
+                              (and ctrlf-go-to-end-of-match
+                                   (match-end 0))
+                              (match-beginning 0)))
                   (setq ctrlf--match-bounds
                         (cons (match-beginning 0)
                               (match-end 0))))

--- a/ctrlf.el
+++ b/ctrlf.el
@@ -862,7 +862,7 @@ For some reason this gets trashed when exiting the minibuffer, so
 we restore it to keep the scroll position consistent.
 
 I have literally no idea why this is needed.")
-"this is a test"
+
 (defun ctrlf--finalize ()
   "Perform cleanup that has to happen after the minibuffer is exited.
 And self-destruct this hook."

--- a/ctrlf.el
+++ b/ctrlf.el
@@ -706,7 +706,7 @@ later (this should be used at the end of the search)."
                 (progn
                   (goto-char (if ctrlf-go-to-end-of-match
                                  (match-end 0)
-                              (match-beginning 0)))
+                               (match-beginning 0)))
                   (setq ctrlf--match-bounds
                         (cons (match-beginning 0)
                               (match-end 0))))


### PR DESCRIPTION
<!--

To expedite the pull request process, please see the contributor guide
for my projects:

  <https://github.com/raxod502/contributor-guide>

-->
See #66
ctrlf won't be isearch-like (e.g. go to the beginning on C-r), because it would need big changes in the source code.
Change t to nil on line 77 if you want the old behavior to be the default.
If someone wants to go to the beginning of a match while still having this as the default, they can use this
```
(defun go-to-beginning-of-match ()
(interactive)
(match-beginning 0))
```
and bind it to a key.