### PR TITLE
Added default and alternative search styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The format is based on [Keep a Changelog].
 [#61]: https://github.com/raxod502/ctrlf/issues/61
 [#67]: https://github.com/raxod502/ctrlf/issues/67
 [#80]: https://github.com/raxod502/ctrlf/issues/80
+[#83]: https://github.com/raxod502/ctrlf/issues/83
 
 ## 1.3 (released 2021-02-26)
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog].
 ## Unreleased
 ### Features
 * Add a new matching style for matching words ([#61]).
+* Add ability to customize default and alternative search styles
+  through `ctrlf-default-search-style` and
+  `ctrlf-alternate-search-style` ([#83]).
 
 ### Bugs fixed
 * Since version 1.2, CTRLF had a number of bugs related to third-party

--- a/README.md
+++ b/README.md
@@ -53,16 +53,19 @@ commands.
 
 Now the usual Isearch bindings will use CTRLF instead:
 
-* `C-s`: `ctrlf-forward-literal` (originally `isearch-forward`)
-* `C-r`: `ctrlf-backward-literal` (originally `isearch-backward`)
-* `C-M-s`: `ctrlf-forward-regexp` (originally
+* `C-s`: `ctrlf-forward-default` (originally `isearch-forward`)
+* `C-r`: `ctrlf-backward-default` (originally `isearch-backward`)
+* `C-M-s`: `ctrlf-forward-alternate` (originally
   `isearch-forward-regexp`)
-* `C-M-r`: `ctrlf-backward-regexp` (originally
+* `C-M-r`: `ctrlf-backward-alternate` (originally
   `isearch-backward-regexp`)
 * `M-s _`: `ctrlf-forward-symbol` (originally
   `isearch-forward-symbol`)
 * `M-s .`: `ctrlf-forward-symbol-at-point` (originally
   `isearch-forward-symbol-at-point`)
+
+See [Customization](#customization) to customize the default and
+alternative search styles.
 
 ## User guide
 
@@ -142,6 +145,17 @@ to insert a default value into the minibuffer. In CTRLF, this default
 value is the symbol at point.
 
 ### Customization
+
+You can customize the search styles of CTRLF:
+
+* User option `ctrlf-default-search-style` specifies the default
+  [search style](#search-styles) (default: `'literal`) that
+  `ctrlf-forward-default` (bound to `C-s` by default) and
+  `ctrlf-backward-default` (bound to `C-r` by default) use.
+* Similarly, user option `ctrlf-alternate-search-style` specifies the
+  alternative [search style](#search-styles) (default: `'regex`) that
+  `ctrlf-forward-alternate` (bound to `C-M-s` by default) and
+  `ctrlf-backward-alternate` (bound to `C-M-r` by default).
 
 You can customize the visual appearance of CTRLF:
 


### PR DESCRIPTION
Implemented the ideas of @raxod502 in https://github.com/raxod502/ctrlf/issues/83#issuecomment-774708394

```
* ctrlf.el (ctrlf-style-alist): Added `:fallback` field.
(ctrlf-mode-bindings): Update binding to use default and alternative
search functions.
(ctrlf-forward-default, ctrlf-backward-default)
(ctrlf-forward-alternate, ctrlf-backward-alternate): New functions.
(ctrlf-forward, ctrlf-backward): Add fallback argument.
(ctrlf-forward-literal, (ctrlf-backward-literal, ctrlf-forward-regexp)
(ctrlf-backward-regexp, ctrlf-forward-symbol): Refactor.
```

