### PR TITLE
Replace ctrlf-mode-bindings and ctrlf-minibuffer-bindings with keymaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ The format is based on [Keep a Changelog].
 * Add ability to customize default and alternative search styles
   through `ctrlf-default-search-style` and
   `ctrlf-alternate-search-style` ([#83]).
+* Keybinding customization is now available via the `ctrlf-mode-map`
+  and the `ctrlf-minibuffer-mode-map` keymaps. Existing customization
+  via `ctrlf-mode-bindings` and `ctrlf-minibuffer-bindings` are still
+  available at the moment to remain backward compatibility but will be
+  deprecated in the future release.([#62])
 
 ### Enhancements
 * When `ctrlf-auto-recenter` is enabled, recentering only begins after
@@ -38,6 +43,7 @@ The format is based on [Keep a Changelog].
 [#51]: https://github.com/raxod502/ctrlf/issues/51
 [#52]: https://github.com/raxod502/ctrlf/issues/52
 [#61]: https://github.com/raxod502/ctrlf/issues/61
+[#62]: https://github.com/raxod502/ctrlf/issues/62
 [#67]: https://github.com/raxod502/ctrlf/issues/67
 [#80]: https://github.com/raxod502/ctrlf/issues/80
 [#83]: https://github.com/raxod502/ctrlf/issues/83

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ The format is based on [Keep a Changelog].
   and the `ctrlf-minibuffer-mode-map` keymaps. Existing customization
   via `ctrlf-mode-bindings` and `ctrlf-minibuffer-bindings` are still
   available at the moment to remain backward compatibility but will be
-  deprecated in the future release.([#62])
+  removed in a future release ([#62]).
 
 ### Enhancements
 * When `ctrlf-auto-recenter` is enabled, recentering only begins after

--- a/README.md
+++ b/README.md
@@ -185,13 +185,13 @@ You can customize the visual appearance of CTRLF:
 
 You can also customize the keybindings:
 
-* User option `ctrlf-mode-bindings` lists keybindings that are made
-  globally available in Emacs when `ctrlf-mode` is enabled.
-* User option `ctrlf-minibuffer-bindings` lists keybindings that are
-  made available in the minibuffer during a CTRLF search session.
+* `ctrlf-mode-map` lists keybindings that are made globally available
+  in Emacs when `ctrlf-mode` is enabled.
+* `ctrlf-minibuffer-mode-map` lists keybindings that are made
+  available in the minibuffer during a CTRLF search session.
 
 In addition to the functions already bound in
-`ctrlf-minibuffer-bindings`, you can choose to bind `ctrlf-next-match`
+`ctrlf-minibuffer-mode-map`, you can choose to bind `ctrlf-next-match`
 and `ctrlf-previous-match`. These functions are the same as
 `ctrlf-forward` and `ctrlf-backward`, but they do not have the special
 features of inserting the previous search, changing to a literal

--- a/ctrlf.el
+++ b/ctrlf.el
@@ -1450,24 +1450,24 @@ search, change back to fuzzy-regexp search."
     "Minor mode to use CTRLF in place of Isearch."
     :keymap ctrlf-mode-map
     (require 'map)
-    (setq default-ctrlf-mode-bindings
-          (eval (car (get 'ctrlf-mode-bindings 'standard-value))))
-    (when (and ctrlf-local-mode
-               default-ctrlf-mode-bindings
-               (not (equal ctrlf-mode-bindings default-ctrlf-mode-bindings)))
-      (when ctrlf--ctrlf-mode-bindings-deprecation-warning
-        (message "The `ctrlf-mode-bindings' will be deprecated. Please use \
+    (let ((default-ctrlf-mode-bindings
+            (eval (car (get 'ctrlf-mode-bindings 'standard-value)))))
+      (when (and ctrlf-local-mode
+                 default-ctrlf-mode-bindings
+                 (not (equal ctrlf-mode-bindings default-ctrlf-mode-bindings)))
+        (when ctrlf--ctrlf-mode-bindings-deprecation-warning
+          (message "The `ctrlf-mode-bindings' will be deprecated. Please use \
 `ctrlf-mode-map' to customize your keybindings instead.")
-        (setq ctrlf--ctrlf-mode-bindings-deprecation-warning nil))
-      ;; Hack to clear out keymap. Presumably there's a `clear-keymap'
-      ;; function lying around somewhere...?
-      (setcdr ctrlf-mode-map nil)
-      (map-apply
-       (lambda (key cmd)
-         (when (stringp key)
-           (setq key (kbd key)))
-         (define-key ctrlf-mode-map key cmd))
-       ctrlf-mode-bindings))
+          (setq ctrlf--ctrlf-mode-bindings-deprecation-warning nil))
+        ;; Hack to clear out keymap. Presumably there's a `clear-keymap'
+        ;; function lying around somewhere...?
+        (setcdr ctrlf-mode-map nil)
+        (map-apply
+         (lambda (key cmd)
+           (when (stringp key)
+             (setq key (kbd key)))
+           (define-key ctrlf-mode-map key cmd))
+         ctrlf-mode-bindings)))
     (with-eval-after-load 'ctrlf
       ;; TODO: This appears to have a bug where if CTRLF is enabled
       ;; globally, then disabled in a particular buffer, then the

--- a/ctrlf.el
+++ b/ctrlf.el
@@ -975,6 +975,8 @@ And self-destruct this hook."
 
 ;;;; Main entry point
 
+(defvar ctrlf--ctrlf-minibuffer-bindings-deprecation-warning t)
+
 (defun ctrlf--start (&optional initial-contents position)
   "Start CTRLF session assuming config vars are set up already.
 Use optional INITIAL-CONTENTS as initial contents and POSITION as
@@ -985,6 +987,10 @@ current starting point."
                (eval (car (get 'ctrlf-minibuffer-bindings 'standard-value))))
         (setq keymap ctrlf-minibuffer-mode-map)
       ;; Else maintain backward compatibility
+      (when ctrlf--ctrlf-minibuffer-bindings-deprecation-warning
+        (ctrlf--message "`ctrlf-minibuffer-bindings' will be deprecated. \
+Please use `ctrlf-minibuffer-mode-map' to customize your keybindings instead.")
+        (setq ctrlf--ctrlf-minibuffer-bindings-deprecation-warning nil))
       (setq keymap (make-sparse-keymap))
       (set-keymap-parent keymap minibuffer-local-map)
       (map-apply
@@ -1435,6 +1441,8 @@ search, change back to fuzzy-regexp search."
 
 ;;;; Minor mode
 
+(defvar ctrlf--ctrlf-mode-bindings-deprecation-warning t)
+
 ;;;###autoload
 (progn
   (define-minor-mode ctrlf-local-mode
@@ -1446,6 +1454,10 @@ search, change back to fuzzy-regexp search."
     (when (and ctrlf-local-mode
                default-ctrlf-mode-bindings
                (not (equal ctrlf-mode-bindings default-ctrlf-mode-bindings)))
+      (when ctrlf--ctrlf-mode-bindings-deprecation-warning
+        (message "The `ctrlf-mode-bindings' will be deprecated. Please use \
+`ctrlf-mode-map' to customize your keybindings instead.")
+        (setq ctrlf--ctrlf-mode-bindings-deprecation-warning nil))
       ;; Hack to clear out keymap. Presumably there's a `clear-keymap'
       ;; function lying around somewhere...?
       (setcdr ctrlf-mode-map nil)

--- a/ctrlf.el
+++ b/ctrlf.el
@@ -977,9 +977,8 @@ And self-destruct this hook."
 
 ;;;; Main entry point
 
-(defvar ctrlf--ctrlf-minibuffer-bindings-deprecation-warning nil
-  "Show a deprecation warning when `ctrlf-minibuffer-bindings' is used.
-This variable will default to non-nil in a future release.")
+(defvar ctrlf--ctrlf-minibuffer-bindings-deprecation-warning t
+  "Show a deprecation warning when `ctrlf-minibuffer-bindings' is used.")
 
 (defun ctrlf--map-keymap (func keymap)
   "Invoke FUNC for each binding in KEYMAP.
@@ -1464,9 +1463,8 @@ search, change back to fuzzy-regexp search."
 
 ;;;; Minor mode
 
-(defvar ctrlf--ctrlf-mode-bindings-deprecation-warning nil
-  "Show a deprecation warning when `ctrlf-mode-bindings' is used.
-This variable will default to non-nil in a future release.")
+(defvar ctrlf--ctrlf-mode-bindings-deprecation-warning t
+  "Show a deprecation warning when `ctrlf-mode-bindings' is used.")
 
 ;;;###autoload
 (progn
@@ -1480,8 +1478,7 @@ This variable will default to non-nil in a future release.")
                  default-ctrlf-mode-bindings
                  (not (equal ctrlf-mode-bindings default-ctrlf-mode-bindings)))
         (when ctrlf--ctrlf-mode-bindings-deprecation-warning
-          (ctrlf--message
-           "Variable `ctrlf-mode-bindings' is deprecated. Please use \
+          (message "Variable `ctrlf-mode-bindings' is deprecated. Please use \
 `ctrlf-mode-map' to customize your keybindings instead.")
           (setq ctrlf--ctrlf-mode-bindings-deprecation-warning nil))
         ;; Hack to clear out keymap. Presumably there's a `clear-keymap'

--- a/ctrlf.el
+++ b/ctrlf.el
@@ -167,7 +167,7 @@ active in the minibuffer during a search."
          (set var val)
          (when (bound-and-true-p ctrlf-mode)
            (ctrlf-mode +1))))
-(make-obsolete-variable 'ctrlf-mode-bindings 'ctrlf-mode-map)
+(make-obsolete-variable 'ctrlf-mode-bindings 'ctrlf-mode-map "2.0")
 
 ;;;###autoload
 (defvar ctrlf-minibuffer-mode-map
@@ -236,7 +236,8 @@ available globally in Emacs when `ctrlf-mode' is active."
   :type '(alist
           :key-type sexp
           :value-type function))
-(make-obsolete-variable 'ctrlf-minibuffer-bindings 'ctrlf-minibuffer-mode-map)
+(make-obsolete-variable 'ctrlf-minibuffer-bindings 'ctrlf-minibuffer-mode-map
+                        "2.0")
 
 (defcustom ctrlf-zero-length-match-width 0.2
   "Width of vertical bar to display for a zero-length match.

--- a/ctrlf.el
+++ b/ctrlf.el
@@ -1431,26 +1431,24 @@ search, change back to fuzzy-regexp search."
 ;;;; Minor mode
 
 ;;;###autoload
-(defvar ctrlf--keymap (make-sparse-keymap)
-  "Keymap for `ctrlf-mode'. Populated when mode is enabled.
-See `ctrlf-mode-bindings'.")
-
-;;;###autoload
 (progn
   (define-minor-mode ctrlf-local-mode
-    "Minor mode to use CTRLF in place of Isearch.
-See `ctrlf-mode-bindings' to customize."
-    :keymap ctrlf--keymap
+    "Minor mode to use CTRLF in place of Isearch."
+    :keymap ctrlf-mode-map
     (require 'map)
-    (when ctrlf-local-mode
+    (setq default-ctrlf-mode-bindings
+          (eval (car (get 'ctrlf-mode-bindings 'standard-value))))
+    (when (and ctrlf-local-mode
+               default-ctrlf-mode-bindings
+               (not (equal ctrlf-mode-bindings default-ctrlf-mode-bindings)))
       ;; Hack to clear out keymap. Presumably there's a `clear-keymap'
       ;; function lying around somewhere...?
-      (setcdr ctrlf--keymap nil)
+      (setcdr ctrlf-mode-map nil)
       (map-apply
        (lambda (key cmd)
          (when (stringp key)
            (setq key (kbd key)))
-         (define-key ctrlf--keymap key cmd))
+         (define-key ctrlf-mode-map key cmd))
        ctrlf-mode-bindings))
     (with-eval-after-load 'ctrlf
       ;; TODO: This appears to have a bug where if CTRLF is enabled

--- a/ctrlf.el
+++ b/ctrlf.el
@@ -980,30 +980,35 @@ And self-destruct this hook."
 Use optional INITIAL-CONTENTS as initial contents and POSITION as
 current starting point."
   (ctrlf--evil-set-jump)
-  (let ((keymap (make-sparse-keymap)))
-    (set-keymap-parent keymap minibuffer-local-map)
-    (map-apply
-     (lambda (key cmd)
-       (when (stringp key)
-         (setq key (kbd key)))
-       (define-key keymap key cmd))
-     ctrlf-minibuffer-bindings)
-    ;; Solve <https://github.com/raxod502/ctrlf/issues/51> without
-    ;; introducing the problems summarized in
-    ;; <https://github.com/raxod502/ctrlf/issues/80> and also reported
-    ;; in <https://github.com/raxod502/ctrlf/issues/67> as well as
-    ;; <https://github.com/raxod502/ctrlf/issues/52>.
-    (map-apply
-     (lambda (key _)
-       (when (stringp key)
-         (setq key (kbd key)))
-       (pcase key
-         (`[remap ,orig-cmd]
-          (when-let ((global-key
-                      (where-is-internal
-                       orig-cmd global-map 'firstonly nil 'no-remap)))
-            (define-key keymap global-key nil)))))
-     ctrlf-mode-bindings)
+  (let ((keymap))
+    (if (equal ctrlf-minibuffer-bindings
+               (eval (car (get 'ctrlf-minibuffer-bindings 'standard-value))))
+        (setq keymap ctrlf-minibuffer-mode-map)
+      ;; Else maintain backward compatibility
+      (setq keymap (make-sparse-keymap))
+      (set-keymap-parent keymap minibuffer-local-map)
+      (map-apply
+       (lambda (key cmd)
+         (when (stringp key)
+           (setq key (kbd key)))
+         (define-key keymap key cmd))
+       ctrlf-minibuffer-bindings)
+      ;; Solve <https://github.com/raxod502/ctrlf/issues/51> without
+      ;; introducing the problems summarized in
+      ;; <https://github.com/raxod502/ctrlf/issues/80> and also reported
+      ;; in <https://github.com/raxod502/ctrlf/issues/67> as well as
+      ;; <https://github.com/raxod502/ctrlf/issues/52>.
+      (map-apply
+       (lambda (key _)
+         (when (stringp key)
+           (setq key (kbd key)))
+         (pcase key
+           (`[remap ,orig-cmd]
+            (when-let ((global-key
+                        (where-is-internal
+                         orig-cmd global-map 'firstonly nil 'no-remap)))
+              (define-key keymap global-key nil)))))
+       ctrlf-mode-bindings))
     (setq ctrlf--starting-point (point))
     (setq ctrlf--current-starting-point (or position (point)))
     (setq ctrlf--last-input nil)

--- a/ctrlf.el
+++ b/ctrlf.el
@@ -127,6 +127,21 @@ search already."
                             (const :case-fold) function)))
 
 ;;;###autoload
+(defvar ctrlf-mode-map
+  (let ((keymap (make-sparse-keymap)))
+    (define-key keymap [remap isearch-forward] #'ctrlf-forward-default)
+    (define-key keymap [remap isearch-backward] #'ctrlf-backward-default)
+    (define-key keymap [remap isearch-forward-regexp]
+      #'ctrlf-forward-alternate)
+    (define-key keymap [remap isearch-backward-regexp]
+      #'ctrlf-backward-alternate)
+    (define-key keymap [remap isearch-forward-symbol] #'ctrlf-forward-symbol)
+    (define-key keymap [remap isearch-forward-symbol-at-point]
+      #'ctrlf-forward-symbol-at-point)
+    keymap)
+  "Keymap used by Ctrlf globally.")
+
+;;;###autoload
 (defcustom ctrlf-mode-bindings
   '(([remap isearch-forward]                 . ctrlf-forward-default)
     ([remap isearch-backward]                . ctrlf-backward-default)
@@ -134,7 +149,10 @@ search already."
     ([remap isearch-backward-regexp]         . ctrlf-backward-alternate)
     ([remap isearch-forward-symbol]          . ctrlf-forward-symbol)
     ([remap isearch-forward-symbol-at-point] . ctrlf-forward-symbol-at-point))
-  "Keybindings enabled in `ctrlf-mode'. This is not a keymap.
+  "This variable is deprecated.
+To customize the keybindings, modify `ctrlf-mode-map' directly.
+
+Keybindings enabled in `ctrlf-mode'. This is not a keymap.
 Rather it is an alist that is converted into a keymap just before
 `ctrlf-mode' is (re-)enabled. The keys are strings or raw key
 events and the values are command symbols.
@@ -149,6 +167,32 @@ active in the minibuffer during a search."
          (set var val)
          (when (bound-and-true-p ctrlf-mode)
            (ctrlf-mode +1))))
+(make-obsolete-variable 'ctrlf-mode-bindings 'ctrlf-mode-map)
+
+;;;###autoload
+(defvar ctrlf-minibuffer-mode-map
+  (let ((keymap (make-sparse-keymap)))
+    (set-keymap-parent keymap minibuffer-local-map)
+    (define-key keymap [remap abort-recursive-edit] #'ctrlf-cancel)
+    (define-key keymap [remap minibuffer-keyboard-quit] #'ctrlf-cancel)
+    (define-key keymap [remap minibuffer-beginning-of-buffer]
+      #'ctrlf-first-match)
+    (define-key keymap [remap beginning-of-buffer] #'ctrlf-first-match)
+    (define-key keymap [remap end-of-buffer] #'ctrlf-last-match)
+    (define-key keymap [remap scroll-up-command] #'ctrlf-next-page)
+    (define-key keymap [remap scroll-down-command] #'ctrlf-previous-page)
+    (define-key keymap [remap recenter-top-bottom] #'ctrlf-recenter-top-bottom)
+    (define-key keymap (kbd "M-s o") #'ctrlf-occur)
+    (define-key keymap (kbd "M-c") #'ctrlf-toggle-case-fold-search)
+    (define-key keymap (kbd "M-s c") #'ctrlf-toggle-case-fold-search)
+    (define-key keymap (kbd "M-r") #'ctrlf-toggle-regexp)
+    (define-key keymap (kbd "M-s r") #'ctrlf-toggle-regexp)
+    (define-key keymap (kbd "M-s _") #'ctrlf-toggle-symbol)
+    (define-key keymap (kbd "M-s s") #'ctrlf-change-search-style)
+    (define-key keymap (kbd "C-o c") #'ctrlf-toggle-case-fold-search)
+    (define-key keymap (kbd "C-o s") #'ctrlf-change-search-style)
+    keymap)
+  "Keymap used by Ctrlf in minibuffer during search.")
 
 (defcustom ctrlf-minibuffer-bindings
   '(([remap abort-recursive-edit]           . ctrlf-cancel)
@@ -178,7 +222,10 @@ active in the minibuffer during a search."
     ;; Previous bindings for backwards compatibility.
     ("C-o c"     . ctrlf-toggle-case-fold-search)
     ("C-o s"     . ctrlf-change-search-style))
-  "Keybindings enabled in minibuffer during search. This is not a keymap.
+  "This variable is deprecated.
+To customize the keybindings, modify `ctrlf-minibuffer-mode-map' directly.
+
+Keybindings enabled in minibuffer during search. This is not a keymap.
 Rather it is an alist that is converted into a keymap just before
 entering the minibuffer. The keys are strings or raw key events
 and the values are command symbols. The keymap so constructed
@@ -189,6 +236,7 @@ available globally in Emacs when `ctrlf-mode' is active."
   :type '(alist
           :key-type sexp
           :value-type function))
+(make-obsolete-variable 'ctrlf-minibuffer-bindings 'ctrlf-minibuffer-mode-map)
 
 (defcustom ctrlf-zero-length-match-width 0.2
   "Width of vertical bar to display for a zero-length match.


### PR DESCRIPTION
First of all, thank you @raxod502 for this awesome package!

I managed to address #62. It'll be great if you can take a look and provide me
your feedback. 🙇 Here's what's happening:

- Add explicit `ctrlf-mode-map` and  `ctrlf-minibuffer-mode-map` keymaps
- Show one-time deprecation warning messages

I'm not sure when would be a good time to finally deprecate the
`ctrl-(mode|minibuffer)-bindings` variables. However, the `make compile` target
insist me to insert a `WHEN` argument to the `make-obsolete-variable` function
call. Since this is a breaking change so I made an educated guess - the next
major release - `"2.0"`. I can change this if needed.

This is my first time contributing to your project (or any Emacs open-source
project.) I think I followed all the things in the contributor guide. Please let
me know if I miss anything.

Credits: 

Also, really appreciate @rgrinberg for the groundwork in #64. I noticed your
work but it was hard for me to build on top of your branch while keeping the git
history clean. I ended up starting from scratch but took some inspiration from
your work. You deserve some credits in this PR!
