### PR TITLE
Keep centered on return with ctrlf-auto-recenter. #90, #81, #92

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,12 @@ The format is based on [Keep a Changelog].
   `ctrlf-message-face`, which defaults to inheriting from
   `minibuffer-prompt` as per previous behavior ([#99]).
 
+### Bugs fixed
+* The window is now less likely to randomly get its scroll position
+  changed when exiting a search ([#113]).
+
 [#99]: https://github.com/raxod502/ctrlf/issues/99
+[#113]: https://github.com/raxod502/ctrlf/pull/113
 
 ## 1.4 (released 2021-12-27)
 ### Features

--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,7 @@ checkindent: ## Ensure that indentation is correct
 	@tmpdir="$$(mktemp -d)"; for file in $(for_checkindent); do \
 	    echo "[checkindent] $$file" >&2; \
 	    emacs -Q --batch \
+		-l scripts/ctrlf-indent.el \
 	        --eval "(setq inhibit-message t)" \
 	        --eval "(load (expand-file-name \"ctrlf.el\") nil t)" \
 	        --eval "(find-file \"$$file\")" \

--- a/ctrlf.el
+++ b/ctrlf.el
@@ -976,7 +976,9 @@ I have literally no idea why this is needed.")
 And self-destruct this hook."
   (remove-hook 'post-command-hook #'ctrlf--finalize)
   (unless (= (point) ctrlf--starting-point)
-    (push-mark ctrlf--starting-point)))
+    (if ctrlf-auto-recenter
+        (set-window-start (get-buffer-window) ctrlf--final-window-start)
+      (push-mark ctrlf--starting-point))))
 
 (defun ctrlf--minibuffer-exit-hook ()
   "Clean up CTRLF from minibuffer and self-destruct this hook."

--- a/ctrlf.el
+++ b/ctrlf.el
@@ -1492,7 +1492,9 @@ search, change back to fuzzy-regexp search."
     "Minor mode to use CTRLF in place of Isearch."
     :keymap ctrlf-mode-map
     (require 'map)
-    (let ((default-ctrlf-mode-bindings
+    ;; Weird indentation to make things indent the same in both Emacs
+    ;; 28 and Emacs 29, because apparently something changed?
+    (let (( default-ctrlf-mode-bindings
             (eval (car (get 'ctrlf-mode-bindings 'standard-value)))))
       (when (and ctrlf-local-mode
                  default-ctrlf-mode-bindings

--- a/scripts/ctrlf-indent.el
+++ b/scripts/ctrlf-indent.el
@@ -1,0 +1,10 @@
+;; This file has code that is evaluated in CI before the indentation
+;; of ctrlf.el is checked. This is helpful because it allows us to
+;; ensure that various things are indented correctly if they require
+;; some setup for Emacs to know how to do the right thing.
+
+;; The indentation of `define-key' has for some reason changed in
+;; Emacs 29 when it was deprecated in favor of `keymap-set'. Maybe
+;; that is a bug and they will change it, but for now, force the
+;; indentation to the backwards-compatible version.
+(put #'define-key 'lisp-indent-function 'defun)


### PR DESCRIPTION
This PR solves (hacks around) the #90 and #81 situation. This whole situation is described in the #92 PR.

#81 is only a relevant problem when `ctrlf-auto-recenter` is not set so in that case use the fix you came up with for #81, otherwise use the fix from jdtsmith from #90.
