### PR TITLE
Make C-g return to initial starting point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,13 @@ The format is based on [Keep a Changelog].
 ### Bugs fixed
 * The window is now less likely to randomly get its scroll position
   changed when exiting a search ([#113]).
+* Previously `C-g` would fail to reset point to its original position
+  in some cases. This has been fixed ([#110], [#114]).
 
 [#99]: https://github.com/radian-software/ctrlf/issues/99
+[#110]: https://github.com/radian-software/ctrlf/issues/110
 [#113]: https://github.com/radian-software/ctrlf/pull/113
+[#114]: https://github.com/radian-software/ctrlf/pull/114
 
 ## 1.4 (released 2021-12-27)
 ### Features

--- a/ctrlf.el
+++ b/ctrlf.el
@@ -177,6 +177,7 @@ active in the minibuffer during a search."
     ;; we have to account for it too.
     (define-key keymap [remap abort-recursive-edit] #'ctrlf-cancel)
     (define-key keymap [remap minibuffer-keyboard-quit] #'ctrlf-cancel)
+    (define-key keymap [remap abort-minibuffers] #'ctrlf-cancel)
     ;; Use `minibuffer-beginning-of-buffer' for Emacs >=27 and
     ;; `beginning-of-buffer' for Emacs <=26.
     (define-key keymap [remap minibuffer-beginning-of-buffer]


### PR DESCRIPTION
C-g by default calls `abort-minibuffers`, and this was not being overridden. As a result, the point was not being restored.
This should address #110 

<!--

To expedite the pull request process, please see the contributor guide
for my projects:

  <https://github.com/raxod502/contributor-guide>

-->
