### PR TITLE
Integrate evil with ctrlf-style-alist.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,14 +8,13 @@ The format is based on [Keep a Changelog].
 * Improved evil-mode's search history integration so it will now use
   the translations defined in `ctrlf-style-alist` ([#124]).
 
-[#124]: https://github.com/radian-software/ctrlf/pull/124
-
 ### Bugs fixed
 * Previously `C-g` would fail to reset point to its original position
   in some cases. This has been fixed ([#110], [#114]).
 
 [#110]: https://github.com/radian-software/ctrlf/issues/110
 [#114]: https://github.com/radian-software/ctrlf/pull/114
+[#124]: https://github.com/radian-software/ctrlf/pull/124
 
 ## 1.5 (released 2022-06-01)
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog].
 
 ## Unreleased
+### Enhancements
+* Improved evil-mode's search history integration so it will now use
+  the translations defined in `ctrlf-style-alist` ([#124]).
+
+[#124]: https://github.com/radian-software/ctrlf/pull/124
+
 ### Bugs fixed
 * Previously `C-g` would fail to reset point to its original position
   in some cases. This has been fixed ([#110], [#114]).

--- a/ctrlf.el
+++ b/ctrlf.el
@@ -677,10 +677,13 @@ Will add search pattern STR to evil's search history ring."
          (setq isearch-string str))
         (evil-search
          (add-to-history 'evil-ex-search-history str)
-         (setq evil-ex-search-pattern (list str nil t))
-         (setq evil-ex-search-direction 'forward)
-         (when evil-ex-search-persistent-highlight
-           (evil-ex-search-activate-highlight evil-ex-search-pattern))))))
+         (let* ((style-plist (alist-get ctrlf--style ctrlf-style-alist))
+                (translator (plist-get style-plist :translator))
+                (translated-str (funcall translator str)))
+           (setq evil-ex-search-direction 'forward
+                 evil-ex-search-pattern (list translated-str nil t))
+           (when evil-ex-search-persistent-highlight
+             (evil-ex-search-activate-highlight evil-ex-search-pattern)))))))
   str)
 
 ;;;; Main loop


### PR DESCRIPTION
Small improvement for the evil integration. Evil will now understand that, for example, `ctrlf-forward-symbol-at-point` for searching for the exact symbol "foo", and no longer continue the search by matching "foobar".
