### PR TITLE
Do not run CI on Emacs master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 name: CI
-on: [push, pull_request]
+on: [pull_request]
 jobs:
   ci:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        emacs_version: [25, 26, 27, "master"]
+        emacs_version: [25, 26, 27, 28]
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
Running against Emacs master is causing maintainability problems because CI will stop working every so often due to upstream changes, not because of anything wrong in PRs.